### PR TITLE
CORE-786 Terraform matrix added to linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,6 +11,10 @@ jobs:
     name: Terraform Linter
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        terraform_version: [1.5.6, 1.10.1] # Actual and latest versions used
+      fail-fast: false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -19,7 +23,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.6"
+          terraform_version: "${{ matrix.terraform_version }}"
 
       - name: Terraform init
         run: terraform init
@@ -39,6 +43,10 @@ jobs:
     name: Terraform Formatter
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        terraform_version: [1.5.6, 1.10.1] # Actual and latest versions used
+      fail-fast: false
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -47,7 +55,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.6"
+          terraform_version: "${{ matrix.terraform_version }}"
 
       - name: Terraform init
         run: terraform init


### PR DESCRIPTION
#### What's new:

 - Terraform matrix added to linter

#### Testing done:

<img width="939" alt="Screenshot 2024-12-11 at 22 05 33" src="https://github.com/user-attachments/assets/1c9b635c-c8ae-4be5-b5a5-a014a3c7c232" />

<img width="770" alt="Screenshot 2024-12-11 at 22 09 38" src="https://github.com/user-attachments/assets/c90f05b2-dd64-43e1-9809-8945918aa5b0" />


Terraform version 1.1.2  removed due to incompatibility with this module.